### PR TITLE
Fix VMF generation prompt handling and add tokenizer tests

### DIFF
--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,32 @@
+import unittest
+
+from vmf_ai.tokenizer import VMFTokenizer
+
+
+class TestVMFTokenizer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tokenizer = VMFTokenizer()
+        self.tokenizer.fit([
+            "worldspawn {\n\t""classname"" \"worldspawn\"\n}",
+            "entity {\n\t""key"" \"value\"\n}",
+        ])
+
+    def test_encode_optional_markers(self) -> None:
+        full = self.tokenizer.encode("worldspawn { }")
+        without_eos = self.tokenizer.encode("worldspawn { }", add_eos=False)
+        self.assertEqual(full[0], self.tokenizer.bos_id)
+        self.assertEqual(full[-1], self.tokenizer.eos_id)
+        self.assertEqual(without_eos[0], self.tokenizer.bos_id)
+        self.assertNotEqual(without_eos[-1], self.tokenizer.eos_id)
+        self.assertNotIn(self.tokenizer.eos_id, without_eos)
+
+    def test_decode_stops_at_eos(self) -> None:
+        tokens = self.tokenizer.encode("worldspawn { }")
+        # Append extra tokens that should never appear in the decoded output.
+        extra = self.tokenizer.encode("entity", add_bos=False, add_eos=False)
+        decoded = self.tokenizer.decode(tokens + extra)
+        self.assertEqual(decoded.strip(), "worldspawn { }")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vmf_ai/__init__.py
+++ b/vmf_ai/__init__.py
@@ -1,9 +1,16 @@
 """Utilities for training and sampling VMF language models."""
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
 from .tokenizer import VMFTokenizer
 from .dataset import VMFDataset, load_vmf_paths
 from .model import ModelConfig, VMFTransformerLM
-from .training import TrainerConfig, train_language_model
-from .generation import generate_vmf_text
+
+if TYPE_CHECKING:  # pragma: no cover - only evaluated by type checkers
+    from .generation import generate_vmf_text
+    from .training import TrainerConfig, train_language_model
 
 __all__ = [
     "VMFTokenizer",
@@ -15,3 +22,13 @@ __all__ = [
     "train_language_model",
     "generate_vmf_text",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"TrainerConfig", "train_language_model"}:
+        module = import_module(".training", __name__)
+        return getattr(module, name)
+    if name == "generate_vmf_text":
+        module = import_module(".generation", __name__)
+        return getattr(module, name)
+    raise AttributeError(name)

--- a/vmf_ai/generation.py
+++ b/vmf_ai/generation.py
@@ -37,7 +37,8 @@ def generate_vmf_text(
     model = model.to(device_obj)
     model.eval()
 
-    encoded = torch.tensor([tokenizer.encode(prompt)], device=device_obj)
+    encoded_prompt = tokenizer.encode(prompt, add_eos=False)
+    encoded = torch.tensor([encoded_prompt], device=device_obj)
     attention_mask = torch.ones_like(encoded)
     generated = model.generate(
         encoded,


### PR DESCRIPTION
## Summary
- allow the tokenizer to omit BOS/EOS markers on demand and stop decoding at the first EOS token
- keep heavy training helpers lazily imported so lightweight tooling works without optional deps
- ensure generation prompts skip the EOS token and add unit tests covering the new tokenizer behaviour

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68de4f8e5ed0832eb7232b24f181921f